### PR TITLE
[서버] hot fix env 포트 넘버 타입 수정

### DIFF
--- a/server/src/@types/node/environment.d.ts
+++ b/server/src/@types/node/environment.d.ts
@@ -2,7 +2,7 @@ declare global {
     namespace NodeJS {
         interface ProcessEnv {
             NODE_ENV: string,
-            PORT: number;
+            PORT: string;
             PUBLIC_SUPABASE_URL: string,
             PUBLIC_SUPABASE_KEY: string,
             JWT_SECRET: string,


### PR DESCRIPTION
issue#36
서버 배포를 위해 ts 파일을 js 파일로 build 하는 과정에서
nodejs 관련 타입 설정 중 environment.d.ts 파일에서 포트 넘버의 타입 지정에 오류가 있는 것을 확인


